### PR TITLE
Fix casting from int to double

### DIFF
--- a/component/src/main/java/org/wso2/extension/siddhi/execution/streamingml/classification/perceptron/PerceptronClassifierUpdaterStreamProcessorExtension.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/execution/streamingml/classification/perceptron/PerceptronClassifierUpdaterStreamProcessorExtension.java
@@ -246,7 +246,7 @@ public class PerceptronClassifierUpdaterStreamProcessorExtension extends StreamP
                 double[] features = new double[numberOfFeatures];
                 for (int i = 0; i < numberOfFeatures; i++) {
                     // attributes cannot ever be any other type than int or double as we've validated the query at init
-                    features[i] = (double) featureVariableExpressionExecutors.get(i).execute(event);
+                    features[i] = ((Number) featureVariableExpressionExecutors.get(i).execute(event)).doubleValue();
                 }
 
                 double[] weights = PerceptronModelsHolder.getInstance().getPerceptronModel(modelName).update(Boolean


### PR DESCRIPTION
## Purpose
Resolves exception happens when casting Java.lang.Interget feature values to double 

## Automation tests
 - Unit tests 
Adds a test case that tries to update the model with both double and integer features. Validates the outputs of the updates.
