### PR TITLE
Remove distribution management tag

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -287,17 +287,4 @@
             </releases>
         </repository>
     </repositories>
-
-    <distributionManagement>
-        <repository>
-            <id>nexus-releases</id>
-            <name>WSO2 Release Distribution Repository</name>
-            <url>http://maven.wso2.org/nexus/service/local/staging/deploy/maven2/</url>
-        </repository>
-        <snapshotRepository>
-            <id>wso2.snapshots</id>
-            <name>Apache Snapshot Repository</name>
-            <url>http://maven.wso2.org/nexus/content/repositories/snapshots/</url>
-        </snapshotRepository>
-    </distributionManagement>
 </project>


### PR DESCRIPTION
This pushes the packages as http, which should be removed. This is inherited from the parent.pom file which pushes as https